### PR TITLE
v2.0.0 - options config, command tuning, and qol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ luac.out
 
 # ignore update script
 update.sh
+user stories.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Macro Sets WoW Addon
 
-## Version 2.0.0 - [3/xx/2025]
+## Version 2.0.0 - [3/7/2025]
 
 - Features: (*Check **Commands** section for more information on all of the features listed below.*)
   - A configuration screen containing 3 toggles is now available in `Interface>AddOns>MacroSets`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog for Macro Sets WoW Addon
 
+## Version 2.0.0 - [3/xx/2025]
+
+- Features: (*Check **Commands** section for more information on all of the features listed below.*)
+  - A configuration screen containing 3 toggles is now available in `Interface-->AddOns-->MacroSets`.
+  - Ability to delete all of your macro sets with a single command.
+  - Ability to undo the most recent `save`, `delete`, `deleteall`, or `undo` command.
+  - Ability to toggle the default type when saving macro sets without a type flag.
+  - In-depth and dynamic help command overhaul that changes content based on current configuration toggles.
+- Changes:
+  - `/ms bars` command has been removed. 
+    - Functionality is now a toggle in the new MacroSets configuration screen.
+  - `/ms icons` command has been removed.
+    - Functionality is now a toggle in the new MacroSets configuration screen.
+  - `/ms help` now prints a list of available commands with short descriptors
+    - `/ms help [command]` prints additional information on usage and functionality of a specific command
+- Commands:
+  - `/ms deleteall`: Delete all macro sets.
+    - Wipe them out, all of them.
+  - `/ms undo`: Undo the most recent action (save, delete, deleteall, undo)
+    - Some example scenarios:
+      - Undo a `save` incase you accidentally overwrite an existing macro set.
+      - Undo a `delete` incase you accidentally delete an existing macro set.
+      - Undo a `deleteall` incase you accidentally deleted all of your existing macro sets.
+      - Undo an `undo` incase you accidentally undid the thing you should actually have done.
+    - Reiterating for emphasis, you only get **1** undo.
+  - `/ms options`: Toggles the MacroSets configuration screen.
+    - Contains toggles for:
+      - Dynamic macro icons (previously `/ms icons`)
+        - Toggled '**ON**':
+          - Macros with names that end with `#i` will be saved with the default/dynamic question mark icon.
+          - All other macros will be saved with the first icon shown when placed on the action bar.
+        - Toggled '**OFF**':
+          - Macros with names that end with `#i` will be saved with the first icon shown when placed on the action bar.
+          - All other macros will be saved with the default/dynamic question mark icon.
+        - Set to '**OFF**' by default.
+      - Action bar placements (previously `/ms bars`)
+        - Toggled '**ON**':
+          - Macros will return to their saved action bar positions on load.
+        - Toggled '**OFF**':
+          - Macros will not return to their saved action bar positions on load.
+        - Set to '**ON**' by default.
+      - Default macro set types
+        - Toggled '**ON**':
+          - Macro sets only save the character specific tab by default.
+        - Toggled '**OFF**':
+          - Macro sets save both the general and the character specific tabs by default.
+        - Set to '**OFF**' by default.
+- Supports World of Warcraft version 11.1.0.
+
 ## Version 1.2.1 - [9/12/2024]
 
 - Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 2.0.0 - [3/xx/2025]
 
 - Features: (*Check **Commands** section for more information on all of the features listed below.*)
-  - A configuration screen containing 3 toggles is now available in `Interface-->AddOns-->MacroSets`.
+  - A configuration screen containing 3 toggles is now available in `Interface>AddOns>MacroSets`.
   - Ability to delete all of your macro sets with a single command.
   - Ability to undo the most recent `save`, `delete`, `deleteall`, or `undo` command.
   - Ability to toggle the default type when saving macro sets without a type flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,13 @@
     - Functionality is now a toggle in the new MacroSets configuration screen.
   - `/ms icons` command has been removed.
     - Functionality is now a toggle in the new MacroSets configuration screen.
-  - `/ms help` now prints a list of available commands with short descriptors
-    - `/ms help [command]` prints additional information on usage and functionality of a specific command
+  - `/ms help` now prints a list of available commands with short descriptors.
+    - `/ms help [command]` prints additional information on usage and functionality of a specific command.
+  - `/ms list` now colorizes the set type indicators for easier differentiation.
 - Commands:
   - `/ms deleteall`: Delete all macro sets.
     - Wipe them out, all of them.
-  - `/ms undo`: Undo the most recent action (save, delete, deleteall, undo)
+  - `/ms undo`: Undo the most recent action (save, delete, deleteall, undo).
     - Some example scenarios:
       - Undo a `save` incase you accidentally overwrite an existing macro set.
       - Undo a `delete` incase you accidentally delete an existing macro set.

--- a/MacroSets.toc
+++ b/MacroSets.toc
@@ -1,4 +1,4 @@
-## Interface: 110005
+## Interface: 110100
 ## Title: Macro Sets
 ## Notes: Manage and switch between macro sets easily.
 ## Author: MattTuccillo

--- a/MacroSets.toc
+++ b/MacroSets.toc
@@ -1,8 +1,8 @@
-## Interface: 110002
+## Interface: 110005
 ## Title: Macro Sets
 ## Notes: Manage and switch between macro sets easily.
 ## Author: MattTuccillo
-## Version: 1.2.1
+## Version: 2.0.0
 ## SavedVariables: MacroSetsDB
 ## IconTexture: Interface\AddOns\MacroSets\Media\Textures\LogoAddon
 ## X-Category: Miscellaneous
@@ -10,3 +10,4 @@
 
 # Include your Lua and XML files here
 Main.lua
+Options.lua

--- a/Main.lua
+++ b/Main.lua
@@ -1,7 +1,7 @@
 --TODO
 --add "undo" command
------delate
------delate all
+-----delete
+-----delete all
 -----save
 --add delete all command with confirmation
 --more filtering for list
@@ -53,6 +53,7 @@ MacroSetsFunctions = MacroSetsFunctions or {}
 MacroSetsDB = MacroSetsDB or {}
 MacroSetsDB.dynamicIcons = MacroSetsDB.dynamicIcons or false
 MacroSetsDB.replaceBars = MacroSetsDB.replaceBars or true
+MacroSetsDB.charSpecific = MacroSetsDB.charSpecific or false
 
 local function AlphabetizeMacroSets()
     if test.alphabetizeMacroSets or test.allFunctions then
@@ -96,6 +97,18 @@ function MacroSetsFunctions.ToggleActionBarPlacements()
     local status = MacroSetsDB.replaceBars and 'ON' or 'OFF'
     if test.toggleActionBarPlacements or test.allFunctions then
         print(COLOR_PURPLE .. "ToggleActionBarPlacements(): Toggled to " .. tostring(MacroSetsDB.replaceBars) .. "." .. COLOR_RESET)
+    end
+end
+
+function MacroSetsFunctions.ToggleCharSpecific()
+    if test.toggleCharSpecific or test.allFunctions then
+        print(COLOR_PURPLE .. "ToggleCharSpecific(): Function called." .. COLOR_RESET)
+    end
+
+    MacroSetsDB.charSpecific = not MacroSetsDB.charSpecific
+    local status = MacroSetsDB.charSpecific and 'ON' or 'OFF'
+    if test.toggleCharSpecific or test.allFunctions then
+        print(COLOR_PURPLE .. "ToggleCharSpecific(): Toggled to " .. tostring(MacroSetsDB.charSpecific) .. "." .. COLOR_RESET)
     end
 end
 
@@ -352,7 +365,11 @@ local function SaveMacroSet(setName, macroType)
 
     local macroType = macroType
     if macroType ~= "c" and macroType ~= "g" then
-        macroType = "both"
+        if MacroSetsDB.charSpecific then
+            macroType = "c"
+        else
+            macroType = "both"
+        end
     end
     local startSlot, endSlot = SetMacroSlotRanges(macroType)
     local generalMacroCount = 0

--- a/Main.lua
+++ b/Main.lua
@@ -32,6 +32,8 @@ local test = {
     handleSlashCommands = false,
     toggleDynamicIcons = false,
     toggleActionBarPlacements = false,
+    toggleCharSpecific = false,
+    optionsScreenToggle = false,
 }
 
 -- Create alphabetized macro set list for easier reference when listed --
@@ -516,6 +518,24 @@ local function ListMacroSets()
     end
 end
 
+local function OptionsScreenToggle()
+    if test.optionsScreenToggle or test.allFunctions then
+        print(COLOR_PURPLE .. "OptionsScreenToggle(): Function called." .. COLOR_RESET)
+    end
+    if SettingsPanel:GetCurrentCategory() == macroSetsCategory and SettingsPanel:IsShown() then
+        SettingsPanel:Hide()
+        if test.optionsScreenToggle or test.allFunctions then
+            print(COLOR_PURPLE .. "OptionsScreenToggle(): Options screen hidden." .. COLOR_RESET)
+        end
+    else
+        SettingsPanel:Hide()
+        SettingsPanel:Show()
+        Settings.OpenToCategory(macroSetsCategory:GetID())
+        if test.optionsScreenToggle or test.allFunctions then
+            print(COLOR_PURPLE .. "OptionsScreenToggle(): Options screen shown." .. COLOR_RESET)
+        end
+    end    
+
 local function DisplayHelp()
     if test.displayHelp or test.allFunctions then
         print(COLOR_PURPLE .. "DisplayHelp(): Function called." .. COLOR_RESET)
@@ -576,14 +596,7 @@ local function HandleSlashCommands(msg)
     elseif command == 'help' then
         DisplayHelp()
     elseif command == 'options' then
-        if SettingsPanel:GetCurrentCategory() == macroSetsCategory and SettingsPanel:IsShown() then
-            SettingsPanel:Hide()
-        else
-            -- Force reset and reopen the panel
-            SettingsPanel:Hide()
-            SettingsPanel:Show()
-            Settings.OpenToCategory(macroSetsCategory:GetID())
-        end    
+        OptionsScreenToggle()
     else
         DisplayDefault()
     end

--- a/Main.lua
+++ b/Main.lua
@@ -669,7 +669,11 @@ local function ListMacroSets()
         local setDetails = MacroSetsDB[setName]
         if type(setDetails) == 'table' and setDetails.macros then
             local setType = setDetails.type
-            local setTypeIndicator = setType == 'c' and "(C)" or setType == 'g' and "(G)" or "(B)"
+            local COLOR_BOTH_INDICATOR = "|cFFFFFF36(B)|r" -- both macro set type indicator
+            local COLOR_GENERAL_INDICATOR = "|cFF36FF4C(G)|r" -- general macro set type indicator
+            local COLOR_CHARACTER_INDICATOR = "|cFF58E5F5(C)|r" -- character macro set type indicator
+            local setTypeIndicator = setType == 'c' and COLOR_CHARACTER_INDICATOR or setType == 'g' and COLOR_GENERAL_INDICATOR or COLOR_BOTH_INDICATOR
+            -- local setTypeIndicator = setType == 'c' and "(C)" or setType == 'g' and "(G)" or "(B)"
             print(COLOR_GREEN .. "- " .. COLOR_RESET .. setTypeIndicator .. setName)
         end
     end
@@ -796,9 +800,9 @@ local function DisplayHelp(helpSection)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms list " .. COLOR_SKY_BLUE .. "to display a list of all existing macro sets." .. COLOR_RESET)
         print(COLOR_SKY_BLUE .. "- Sets will note the set type they encompass." .. COLOR_RESET)
-        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_RESET .. "(G) " .. COLOR_LIGHT_BLUE .. "for general macros." .. COLOR_RESET)
-        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_RESET .. "(C) " .. COLOR_LIGHT_BLUE .. "for character-specific macros." .. COLOR_RESET)
-        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_RESET .. "(B) " .. COLOR_LIGHT_BLUE .. "for both general and character-specific macros." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_RESET .. "(G) " .. COLOR_LIGHT_BLUE .. "in green for general macros." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_RESET .. "(C) " .. COLOR_LIGHT_BLUE .. "in blue for character-specific macros." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_RESET .. "(B) " .. COLOR_LIGHT_BLUE .. "in yellow for both general and character-specific macros." .. COLOR_RESET)
         print(COLOR_SKY_BLUE .. "- Sets will be ordered alphabetically." .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         return

--- a/Main.lua
+++ b/Main.lua
@@ -1,15 +1,3 @@
---TODO
---add "undo" command
------delete
------delete all
------save
---add delete all command with confirmation
---more filtering for list
---adjust readme
---adjust help
---adjust changelog
---new command to open options '/ms options'
-
 -- Color codes
 local COLOR_PURPLE = "|cFFCC79A7" -- testing messages
 local COLOR_SKY_BLUE = "|cFF56B4E9" -- help section text
@@ -587,6 +575,15 @@ local function HandleSlashCommands(msg)
         ListMacroSets()
     elseif command == 'help' then
         DisplayHelp()
+    elseif command == 'options' then
+        if SettingsPanel:GetCurrentCategory() == macroSetsCategory and SettingsPanel:IsShown() then
+            SettingsPanel:Hide()
+        else
+            -- Force reset and reopen the panel
+            SettingsPanel:Hide()
+            SettingsPanel:Show()
+            Settings.OpenToCategory(macroSetsCategory:GetID())
+        end    
     else
         DisplayDefault()
     end

--- a/Main.lua
+++ b/Main.lua
@@ -1,3 +1,16 @@
+--TODO
+--remove commands for dynamic icons and bar placement toggles
+--add "undo" command
+-----delate
+-----delate all
+-----save
+--add delete all command with confirmation
+--more filtering for list
+--adjust readme
+--adjust help
+--adjust changelog
+--new command to open options '/ms options'
+
 -- Color codes
 local COLOR_PURPLE = "|cFFCC79A7" -- testing messages
 local COLOR_SKY_BLUE = "|cFF56B4E9" -- help section text
@@ -70,7 +83,6 @@ function MacroSetsFunctions.ToggleDynamicIcons()
 
     MacroSetsDB.dynamicIcons = not MacroSetsDB.dynamicIcons
     local status = MacroSetsDB.dynamicIcons and 'ON' or 'OFF'
-    print("Dynamic macro icons toggled " .. COLOR_ORANGE .. "'" .. status .. "'" .. COLOR_RESET .. ".")
     if test.toggleDynamicIcons or test.allFunctions then
         print(COLOR_PURPLE .. "ToggleDynamicIcons(): Toggled to " .. tostring(MacroSetsDB.dynamicIcons) .. "." .. COLOR_RESET)
     end
@@ -557,10 +569,6 @@ local function HandleSlashCommands(msg)
     elseif command == 'list' then
         AlphabetizeMacroSets()
         ListMacroSets()
-    -- elseif command == 'icons' then
-    --     ToggleDynamicIcons()
-    -- elseif command == 'bars' then
-    --     ToggleActionBarPlacements()
     elseif command == 'help' then
         DisplayHelp()
     else

--- a/Main.lua
+++ b/Main.lua
@@ -21,6 +21,7 @@ local test = {
     saveMacroSet = false,
     loadMacroSet = false,
     deleteMacroSet = false,
+    deleteAllMacroSets = false,
     undoLastOperation = false,
     listMacroSets = false,
     displayHelp = false,
@@ -61,15 +62,7 @@ MacroSetsDB = MacroSetsDB or {}
 MacroSetsDB.dynamicIcons = MacroSetsDB.dynamicIcons or false
 MacroSetsDB.replaceBars = MacroSetsDB.replaceBars or true
 MacroSetsDB.charSpecific = MacroSetsDB.charSpecific or false
-
--- Create a backup of all macro sets for restoration through undo --
 MacroSetsBackup = MacroSetsBackup or {}
-if next(MacroSetsBackup) == nil then
-    for setName, setData in pairs(MacroSetsDB) do
-        MacroSetsBackup[setName] = DeepCopyTable(setData)
-    end
-end
-
 
 function MacroSetsFunctions.ToggleDynamicIcons()
     if test.toggleDynamicIcons or test.allFunctions then
@@ -363,6 +356,41 @@ local function DeleteMacroSet(setName)
     if test.deleteMacroSet or test.allFunctions then
         if MacroSetsDB[setName] == nil then
             print(COLOR_PURPLE .. "DeleteMacroSet(): Successfully deleted " .. setName .. "." .. COLOR_RESET)
+        end
+    end
+end
+
+local function DeleteAllMacroSets()
+    -- Test callback
+    if test.deleteAllMacroSets or test.allFunctions then
+        print(COLOR_PURPLE .. "DeleteAllMacroSets(): Function called." .. COLOR_RESET)
+    end
+
+    -- Backup current macro sets
+    BackupMacroSets()
+
+    -- Delete all macro sets
+    for setName in pairs(MacroSetsDB) do
+        if type(MacroSetsDB[setName]) == "table" then
+            MacroSetsDB[setName] = nil
+        end
+    end
+
+    print(COLOR_GREEN .. "All macro sets have been deleted." .. COLOR_RESET)
+
+    -- Test callback
+    if test.deleteAllMacroSets or test.allFunctions then
+        local foundTable = false
+        for setName in pairs(MacroSetsDB) do
+            if type(MacroSetsDB[setName]) == "table" then
+                foundTable = true
+                break
+            end
+        end
+        if foundTable then
+            print(COLOR_PURPLE .. "DeleteAllMacroSets(): Failed to delete all macro sets." .. COLOR_RESET)
+        else
+            print(COLOR_PURPLE .. "DeleteAllMacroSets(): Successfully deleted all macro sets." .. COLOR_RESET)
         end
     end
 end
@@ -710,6 +738,8 @@ local function HandleSlashCommands(msg)
         LoadMacroSet(setName)
     elseif command == 'delete' then
         DeleteMacroSet(setName)
+    elseif command == 'deleteall' then
+        DeleteAllMacroSets()
     elseif command == 'undo' then
         UndoLastOperation()
     elseif command == 'list' then

--- a/Main.lua
+++ b/Main.lua
@@ -37,9 +37,10 @@ local test = {
 -- Create alphabetized macro set list for easier reference when listed --
 local sortedSetNames = {}
 local actionBarSlotLimit = 180
+MacroSetsFunctions = MacroSetsFunctions or {}
 MacroSetsDB = MacroSetsDB or {}
 MacroSetsDB.dynamicIcons = MacroSetsDB.dynamicIcons or false
-MacroSetsDB.placeOnBars = MacroSetsDB.placeOnBars or true
+MacroSetsDB.replaceBars = MacroSetsDB.replaceBars or true
 
 local function AlphabetizeMacroSets()
     if test.alphabetizeMacroSets or test.allFunctions then
@@ -62,7 +63,7 @@ local function AlphabetizeMacroSets()
     end
 end
 
-local function ToggleDynamicIcons()
+function MacroSetsFunctions.ToggleDynamicIcons()
     if test.toggleDynamicIcons or test.allFunctions then
         print(COLOR_PURPLE .. "ToggleDynamicIcons(): Function called." .. COLOR_RESET)
     end
@@ -75,16 +76,15 @@ local function ToggleDynamicIcons()
     end
 end
 
-local function ToggleActionBarPlacements()
+function MacroSetsFunctions.ToggleActionBarPlacements()
     if test.toggleActionBarPlacements or test.allFunctions then
         print(COLOR_PURPLE .. "ToggleActionBarPlacements(): Function called." .. COLOR_RESET)
     end
 
-    MacroSetsDB.placeOnBars = not MacroSetsDB.placeOnBars
-    local status = MacroSetsDB.placeOnBars and 'OFF' or 'ON'
-    print("Action bar placements on load toggled " .. COLOR_ORANGE .. "'" .. status .. "'" .. COLOR_RESET .. ".")
+    MacroSetsDB.replaceBars = not MacroSetsDB.replaceBars
+    local status = MacroSetsDB.replaceBars and 'ON' or 'OFF'
     if test.toggleActionBarPlacements or test.allFunctions then
-        print(COLOR_PURPLE .. "ToggleActionBarPlacements(): Toggled to " .. tostring(MacroSetsDB.placeOnBars) .. "." .. COLOR_RESET)
+        print(COLOR_PURPLE .. "ToggleActionBarPlacements(): Toggled to " .. tostring(MacroSetsDB.replaceBars) .. "." .. COLOR_RESET)
     end
 end
 
@@ -454,7 +454,7 @@ local function LoadMacroSet(setName)
             break
         end
         positions = macro.position or {}
-        if MacroSetsDB.placeOnBars == false then
+        if MacroSetsDB.replaceBars == true then
             if macroIndex and #positions ~= 0 then
                 PlaceMacroInActionBarSlots(macroIndex, positions)
             end
@@ -557,10 +557,10 @@ local function HandleSlashCommands(msg)
     elseif command == 'list' then
         AlphabetizeMacroSets()
         ListMacroSets()
-    elseif command == 'icons' then
-        ToggleDynamicIcons()
-    elseif command == 'bars' then
-        ToggleActionBarPlacements()
+    -- elseif command == 'icons' then
+    --     ToggleDynamicIcons()
+    -- elseif command == 'bars' then
+    --     ToggleActionBarPlacements()
     elseif command == 'help' then
         DisplayHelp()
     else

--- a/Main.lua
+++ b/Main.lua
@@ -5,7 +5,7 @@ local COLOR_LIGHT_BLUE = "|cFFADD8E6" -- help section bullets
 local COLOR_PINK = "|cFFF4B183" -- help section examples
 local COLOR_YELLOW = "|cFFF0E442" -- help section commands
 local COLOR_ORANGE = "|cFFE69F00" -- help section parameters
-local COLOR_BLUE = "|cFF0072B2" -- headings
+local COLOR_BLUE = "|cFF0072B2" -- heading dividers
 local COLOR_VERMILLION = "|cFFD55E00" -- error message
 local COLOR_GREEN = "|cFF009E73" -- success message
 local COLOR_RESET = "|r" -- reset back to original color
@@ -59,9 +59,17 @@ local sortedSetNames = {}
 local actionBarSlotLimit = 180
 MacroSetsFunctions = MacroSetsFunctions or {}
 MacroSetsDB = MacroSetsDB or {}
-MacroSetsDB.dynamicIcons = MacroSetsDB.dynamicIcons or false
-MacroSetsDB.replaceBars = MacroSetsDB.replaceBars or true
-MacroSetsDB.charSpecific = MacroSetsDB.charSpecific or false
+
+if MacroSetsDB.dynamicIcons == nil then
+    MacroSetsDB.dynamicIcons = false
+end
+if MacroSetsDB.replaceBars == nil then
+    MacroSetsDB.replaceBars = true
+end
+if MacroSetsDB.charSpecific == nil then
+    MacroSetsDB.charSpecific = false
+end
+
 MacroSetsBackup = MacroSetsBackup or {}
 
 function MacroSetsFunctions.ToggleDynamicIcons()
@@ -654,7 +662,9 @@ local function ListMacroSets()
         return
     end
 
-    print(COLOR_YELLOW .. "Saved Macro Sets:" .. COLOR_RESET)
+    print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+    print("Saved Macro Sets:" .. COLOR_RESET)
+    print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
     for _, setName in ipairs(sortedSetNames) do
         local setDetails = MacroSetsDB[setName]
         if type(setDetails) == 'table' and setDetails.macros then
@@ -663,6 +673,7 @@ local function ListMacroSets()
             print(COLOR_GREEN .. "- " .. COLOR_RESET .. setTypeIndicator .. setName)
         end
     end
+    print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
 end
 
 local function OptionsScreenToggle()
@@ -684,37 +695,6 @@ local function OptionsScreenToggle()
     end
 end    
 
-local function DisplayHelp()
-    if test.displayHelp or test.allFunctions then
-        print(COLOR_PURPLE .. "DisplayHelp(): Function called." .. COLOR_RESET)
-    end
-
-    print(COLOR_BLUE .. "Macro Sets Addon - Help" .. COLOR_RESET)
-    print(COLOR_YELLOW .. "/ms save [name] [type]" .. COLOR_SKY_BLUE .. " - Save the current macro set with the specified name." .. COLOR_RESET) 
-    print(COLOR_PINK .. "  Example: /ms save mySet g" .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "- " .. COLOR_ORANGE .. "[name]" .. COLOR_LIGHT_BLUE .. " 50 characters limit. No spaces." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "- " .. COLOR_ORANGE .. "[type]" .. COLOR_LIGHT_BLUE .. " Defaults to " .. COLOR_ORANGE .. "'both'" .. COLOR_LIGHT_BLUE .." if omitted." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "'g'" .. COLOR_LIGHT_BLUE .. " for general macros tab." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "'c'" .. COLOR_LIGHT_BLUE .. " for character macros tab." .. COLOR_RESET)
-    print(COLOR_YELLOW .. "/ms load [name]" .. COLOR_SKY_BLUE .. " - Load the macro set with the specified name." .. COLOR_RESET)
-    print(COLOR_YELLOW .. "/ms delete [name]" .. COLOR_SKY_BLUE .. " - Delete the macro set with the specified name." .. COLOR_RESET)
-    print(COLOR_YELLOW .. "/ms list" .. COLOR_SKY_BLUE .. " - List all saved macro sets." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "- Sets will note the tab type they encompass." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "- Sets will be alphabetized." .. COLOR_RESET)
-    print(COLOR_YELLOW .. "/ms bars" .. COLOR_SKY_BLUE .. " - Toggle whether you want the macros to return to their saved action bar positions on load." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "- Set to " .. COLOR_ORANGE .. "'ON'" .. COLOR_LIGHT_BLUE .. " by default." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "- Due to the nature of the addon, setting to " .. COLOR_ORANGE .. "'OFF'" .. COLOR_LIGHT_BLUE .. " means all macros will be removed from bars on load." .. COLOR_RESET)
-    print(COLOR_YELLOW .. "/ms icons" .. COLOR_SKY_BLUE .. " - Toggle what the '#i' flag does at the end of macro names." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "- Toggled " .. COLOR_ORANGE .. "'ON'" .. COLOR_LIGHT_BLUE .. ":" .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "  - Macros with names that end with ".. COLOR_ORANGE .. "'#i'" .. COLOR_LIGHT_BLUE .. " will be saved with the default/dynamic question mark icon." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "  - All other macros will be saved with the first icon shown when placed on the action bar." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "- Toggled " .. COLOR_ORANGE .. "'OFF'" .. COLOR_LIGHT_BLUE .. ":" .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "  - Macros with names that end with " .. COLOR_ORANGE .. "'#i'" .. COLOR_LIGHT_BLUE .. " will be saved with the first icon shown when placed on the action bar." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "  - All other macros will be saved with the default/dynamic question mark icon." .. COLOR_RESET)
-    print(COLOR_LIGHT_BLUE .. "- Set to " .. COLOR_ORANGE .. "'OFF'" .. COLOR_LIGHT_BLUE .. " by default." .. COLOR_RESET)
-    print(COLOR_YELLOW .. "/ms help" .. COLOR_SKY_BLUE .. " - Display this help message." .. COLOR_RESET)
-end
-
 local function DisplayDefault()
     if test.displayDefault or test.allFunctions then
         print(COLOR_PURPLE .. "DisplayDefault(): Function called." .. COLOR_RESET)
@@ -723,21 +703,123 @@ local function DisplayDefault()
     print(COLOR_VERMILLION .. "Invalid Command: Type " .. COLOR_YELLOW .. "'/ms help'" .. COLOR_VERMILLION .. " for a list of valid commands." .. COLOR_RESET)
 end
 
+local function DisplayHelp(helpSection)
+    if test.displayHelp or test.allFunctions then
+        print(COLOR_PURPLE .. "DisplayHelp(): Function called." .. COLOR_RESET)
+    end
+
+    if helpSection == nil then
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print("Macro Sets - Help" .. COLOR_RESET)
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms save [name] [type]" .. COLOR_SKY_BLUE .. " - Save the current macro set with the specified name." .. COLOR_RESET) 
+        print(COLOR_YELLOW .. "/ms load [name]" .. COLOR_SKY_BLUE .. " - Load the macro set with the specified name." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms delete [name]" .. COLOR_SKY_BLUE .. " - Delete the macro set with the specified name." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms deleteall" .. COLOR_SKY_BLUE .. " - Delete all saved macro sets." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms undo" .. COLOR_SKY_BLUE .. " - Undo the last operation." .. COLOR_RESET)
+        -- print(COLOR_LIGHT_BLUE .. "- Can revert previous save, delete, or deleteall operation." .. COLOR_RESET)
+        -- print(COLOR_LIGHT_BLUE .. "- Consecutive call will undo the undo." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms list" .. COLOR_SKY_BLUE .. " - List all saved macro sets." .. COLOR_RESET)
+        -- print(COLOR_LIGHT_BLUE .. "- Sets will note the tab type they encompass." .. COLOR_RESET)
+        -- print(COLOR_LIGHT_BLUE .. "- Sets will be alphabetized." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms options" .. COLOR_SKY_BLUE .. " - Open the options screen." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms help [command]" .. COLOR_SKY_BLUE .. " - Display detailed information about a specific command." .. COLOR_RESET)
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+    elseif helpSection == "save" then
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print("Macro Sets - Help: Save" .. COLOR_RESET)
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms save [name] [type]" .. COLOR_SKY_BLUE .. " to save the current macro set." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[name]" .. COLOR_LIGHT_BLUE .. " 50 characters limit. No spaces." .. COLOR_RESET)
+        if (MacroSetsDB.charSpecific) then
+            print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[type]" .. COLOR_LIGHT_BLUE .. " Defaults to " .. COLOR_ORANGE .. "'c'" .. COLOR_LIGHT_BLUE .." if omitted." .. COLOR_RESET)
+        else
+            print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[type]" .. COLOR_LIGHT_BLUE .. " Defaults to " .. COLOR_ORANGE .. "'both'" .. COLOR_LIGHT_BLUE .." if omitted." .. COLOR_RESET)
+        end
+        print(COLOR_LIGHT_BLUE .. "    - " .. COLOR_ORANGE .. "'g'" .. COLOR_LIGHT_BLUE .. " for general macros tab." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "    - " .. COLOR_ORANGE .. "'c'" .. COLOR_LIGHT_BLUE .. " for character macros tab." .. COLOR_RESET)
+        if (MacroSetsDB.dynamicIcons) then
+            print(COLOR_SKY_BLUE .. "- By default icons are stored with the |T134400:0|t icon when saved." .. COLOR_RESET)
+            print(COLOR_LIGHT_BLUE .. "  - Macro names ending with " .. COLOR_RESET .. "'#i'" .. COLOR_LIGHT_BLUE .. " are stored as they appeared when saved." .. COLOR_RESET)
+        else
+            print(COLOR_SKY_BLUE .. "- By default icons are stored as they appeared when saved." .. COLOR_RESET)
+            print(COLOR_LIGHT_BLUE .. "  - Macro names ending with " .. COLOR_RESET .. "'#i'" .. COLOR_LIGHT_BLUE .. " are stored with the |T134400:0|t icon when saved." .. COLOR_RESET)
+        end
+        print(COLOR_LIGHT_BLUE .. "  - |T134400:0|t icon changes based upon macro text content." .. COLOR_RESET)
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+    elseif helpSection == "load" then
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print("Macro Sets - Help: Load" .. COLOR_RESET)
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms load [name]" .. COLOR_SKY_BLUE .. " to load a specific macro set." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[name]" .. COLOR_LIGHT_BLUE .. " Must exist to successfully load." .. COLOR_RESET)
+        if (MacroSetsDB.replaceBars) then
+            print(COLOR_SKY_BLUE .. "- By default macros are placed in the action bar slots they were saved in when loaded." .. COLOR_RESET)
+            print(COLOR_LIGHT_BLUE .. "  - Existing items in the action bar slot will be overwritten." .. COLOR_RESET)
+        else
+            print(COLOR_SKY_BLUE .. "- By default macros are not placed in the action bar slots they were saved in when loaded." .. COLOR_RESET)
+            print(COLOR_LIGHT_BLUE .. "  - Macros will only be loaded into the macro frame." .. COLOR_RESET)
+        end
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        return
+    elseif helpSection == "delete" then
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print("Macro Sets - Help: Delete" .. COLOR_RESET)
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        return
+    elseif helpSection == "deleteall" then
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print("Macro Sets - Help: Delete All" .. COLOR_RESET)
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        return
+    elseif helpSection == "undo" then
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print("Macro Sets - Help: Undo" .. COLOR_RESET)
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        return
+    elseif helpSection == "list" then
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print("Macro Sets - Help: List" .. COLOR_RESET)
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        return
+    elseif helpSection == "options" then
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        print("Macro Sets - Help: Options" .. COLOR_RESET)
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        
+        print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
+        return
+    else
+        DisplayDefault()
+    end
+end
+
 local function HandleSlashCommands(msg)
     if test.handleSlashCommands or test.allFunctions then
         print(COLOR_PURPLE .. "HandleSlashCommands(): Function called." .. COLOR_RESET)
     end
 
     msg = string.match(msg, "^%s*(.-)%s*$")
-    local command, setName, macroType = strsplit(" ", msg)
+    local command, arg1, arg2 = strsplit(" ", msg)
     command = string.lower(command)
 
     if command == 'save' then
-        SaveMacroSet(setName, macroType)
+        -- arg1 = setName, arg2 = macroType
+        SaveMacroSet(arg1, arg2)
     elseif command == 'load' then
-        LoadMacroSet(setName)
+        -- arg1 = setName
+        LoadMacroSet(arg1)
     elseif command == 'delete' then
-        DeleteMacroSet(setName)
+        -- arg1 = setName
+        DeleteMacroSet(arg1)
     elseif command == 'deleteall' then
         DeleteAllMacroSets()
     elseif command == 'undo' then
@@ -746,7 +828,8 @@ local function HandleSlashCommands(msg)
         AlphabetizeMacroSets()
         ListMacroSets()
     elseif command == 'help' then
-        DisplayHelp()
+        -- arg1 = helpSection
+        DisplayHelp(arg1)
     elseif command == 'options' then
         OptionsScreenToggle()
     else

--- a/Main.lua
+++ b/Main.lua
@@ -710,49 +710,46 @@ local function DisplayHelp(helpSection)
 
     if helpSection == nil then
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
-        print("Macro Sets - Help" .. COLOR_RESET)
+        print("Macro Sets - Help: General" .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
-        print(COLOR_YELLOW .. "/ms save [name] [type]" .. COLOR_SKY_BLUE .. " - Save the current macro set with the specified name." .. COLOR_RESET) 
-        print(COLOR_YELLOW .. "/ms load [name]" .. COLOR_SKY_BLUE .. " - Load the macro set with the specified name." .. COLOR_RESET)
-        print(COLOR_YELLOW .. "/ms delete [name]" .. COLOR_SKY_BLUE .. " - Delete the macro set with the specified name." .. COLOR_RESET)
-        print(COLOR_YELLOW .. "/ms deleteall" .. COLOR_SKY_BLUE .. " - Delete all saved macro sets." .. COLOR_RESET)
-        print(COLOR_YELLOW .. "/ms undo" .. COLOR_SKY_BLUE .. " - Undo the last operation." .. COLOR_RESET)
-        -- print(COLOR_LIGHT_BLUE .. "- Can revert previous save, delete, or deleteall operation." .. COLOR_RESET)
-        -- print(COLOR_LIGHT_BLUE .. "- Consecutive call will undo the undo." .. COLOR_RESET)
-        print(COLOR_YELLOW .. "/ms list" .. COLOR_SKY_BLUE .. " - List all saved macro sets." .. COLOR_RESET)
-        -- print(COLOR_LIGHT_BLUE .. "- Sets will note the tab type they encompass." .. COLOR_RESET)
-        -- print(COLOR_LIGHT_BLUE .. "- Sets will be alphabetized." .. COLOR_RESET)
-        print(COLOR_YELLOW .. "/ms options" .. COLOR_SKY_BLUE .. " - Open the options screen." .. COLOR_RESET)
-        print(COLOR_YELLOW .. "/ms help [command]" .. COLOR_SKY_BLUE .. " - Display detailed information about a specific command." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms save [name] [type] " .. COLOR_SKY_BLUE .. "- Save the current macro set with the specified name." .. COLOR_RESET) 
+        print(COLOR_YELLOW .. "/ms load [name] " .. COLOR_SKY_BLUE .. "- Load the macro set with the specified name." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms delete [name] " .. COLOR_SKY_BLUE .. "- Delete the macro set with the specified name." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms deleteall " .. COLOR_SKY_BLUE .. "- Delete all saved macro sets." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms undo " .. COLOR_SKY_BLUE .. "- Undo the last eligible action." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms list " .. COLOR_SKY_BLUE .. "- List all saved macro sets." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms options " .. COLOR_SKY_BLUE .. "- Toggle the options screen." .. COLOR_RESET)
+        print(COLOR_YELLOW .. "/ms help [command] " .. COLOR_SKY_BLUE .. "- Display detailed information about a specific command." .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
     elseif helpSection == "save" then
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         print("Macro Sets - Help: Save" .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
-        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms save [name] [type]" .. COLOR_SKY_BLUE .. " to save the current macro set." .. COLOR_RESET)
-        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[name]" .. COLOR_LIGHT_BLUE .. " 50 characters limit. No spaces." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms save [name] [type] " .. COLOR_SKY_BLUE .. "to save the current macro set." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[name] " .. COLOR_LIGHT_BLUE .. "50 characters limit. No spaces." .. COLOR_RESET)
         if (MacroSetsDB.charSpecific) then
-            print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[type]" .. COLOR_LIGHT_BLUE .. " Defaults to " .. COLOR_ORANGE .. "'c'" .. COLOR_LIGHT_BLUE .." if omitted." .. COLOR_RESET)
+            print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[type] " .. COLOR_LIGHT_BLUE .. "Defaults to " .. COLOR_ORANGE .. "'c' " .. COLOR_LIGHT_BLUE .."if omitted." .. COLOR_RESET)
         else
-            print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[type]" .. COLOR_LIGHT_BLUE .. " Defaults to " .. COLOR_ORANGE .. "'both'" .. COLOR_LIGHT_BLUE .." if omitted." .. COLOR_RESET)
+            print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[type] " .. COLOR_LIGHT_BLUE .. "Defaults to " .. COLOR_ORANGE .. "'both' " .. COLOR_LIGHT_BLUE .."if omitted." .. COLOR_RESET)
         end
-        print(COLOR_LIGHT_BLUE .. "    - " .. COLOR_ORANGE .. "'g'" .. COLOR_LIGHT_BLUE .. " for general macros tab." .. COLOR_RESET)
-        print(COLOR_LIGHT_BLUE .. "    - " .. COLOR_ORANGE .. "'c'" .. COLOR_LIGHT_BLUE .. " for character macros tab." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "    - " .. COLOR_ORANGE .. "'g' " .. COLOR_LIGHT_BLUE .. "for general macros tab." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "    - " .. COLOR_ORANGE .. "'c' " .. COLOR_LIGHT_BLUE .. "for character macros tab." .. COLOR_RESET)
         if (MacroSetsDB.dynamicIcons) then
             print(COLOR_SKY_BLUE .. "- By default icons are stored with the |T134400:0|t icon when saved." .. COLOR_RESET)
-            print(COLOR_LIGHT_BLUE .. "  - Macro names ending with " .. COLOR_RESET .. "'#i'" .. COLOR_LIGHT_BLUE .. " are stored as they appeared when saved." .. COLOR_RESET)
+            print(COLOR_LIGHT_BLUE .. "  - Macro names ending with " .. COLOR_RESET .. "'#i' " .. COLOR_LIGHT_BLUE .. "are stored as they appeared when saved." .. COLOR_RESET)
         else
             print(COLOR_SKY_BLUE .. "- By default icons are stored as they appeared when saved." .. COLOR_RESET)
-            print(COLOR_LIGHT_BLUE .. "  - Macro names ending with " .. COLOR_RESET .. "'#i'" .. COLOR_LIGHT_BLUE .. " are stored with the |T134400:0|t icon when saved." .. COLOR_RESET)
+            print(COLOR_LIGHT_BLUE .. "  - Macro names ending with " .. COLOR_RESET .. "'#i' " .. COLOR_LIGHT_BLUE .. "are stored with the |T134400:0|t icon when saved." .. COLOR_RESET)
         end
         print(COLOR_LIGHT_BLUE .. "  - |T134400:0|t icon changes based upon macro text content." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- Saving is an undo-able action." .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
     elseif helpSection == "load" then
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         print("Macro Sets - Help: Load" .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
-        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms load [name]" .. COLOR_SKY_BLUE .. " to load a specific macro set." .. COLOR_RESET)
-        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[name]" .. COLOR_LIGHT_BLUE .. " Must exist to successfully load." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms load [name] " .. COLOR_SKY_BLUE .. "to load a specific macro set." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[name] " .. COLOR_LIGHT_BLUE .. "Must exist to successfully load." .. COLOR_RESET)
         if (MacroSetsDB.replaceBars) then
             print(COLOR_SKY_BLUE .. "- By default macros are placed in the action bar slots they were saved in when loaded." .. COLOR_RESET)
             print(COLOR_LIGHT_BLUE .. "  - Existing items in the action bar slot will be overwritten." .. COLOR_RESET)
@@ -766,35 +763,53 @@ local function DisplayHelp(helpSection)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         print("Macro Sets - Help: Delete" .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
-
+        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms delete [name] " .. COLOR_SKY_BLUE .. "to delete a specific macro set." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_ORANGE .. "[name] " .. COLOR_LIGHT_BLUE .. "Must exist to successfully delete." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- Deleting is an undo-able action." .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         return
     elseif helpSection == "deleteall" then
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         print("Macro Sets - Help: Delete All" .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
-
+        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms deleteall " .. COLOR_SKY_BLUE .. "to delete all macro sets." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- Deleting all is an undo-able action." .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         return
     elseif helpSection == "undo" then
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         print("Macro Sets - Help: Undo" .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
-
+        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms undo " .. COLOR_SKY_BLUE .. "to revert the changes from a previous action." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - Saving can be undone if you save over a macro set accidentally." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - Deleting can be undone if you delete a macro set accidentally." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - Deleting all can be undone if you delete all macro sets accidentally." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - Undoing can be undone if you want to redo something you undid." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- The stored backup persists across sessions." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - You can perform an action, logout, log back in, and then undo the previous action later." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- The stored backup is shared across all characters." .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         return
     elseif helpSection == "list" then
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         print("Macro Sets - Help: List" .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
-
+        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms list " .. COLOR_SKY_BLUE .. "to display a list of all existing macro sets." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- Sets will note the set type they encompass." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_RESET .. "(G) " .. COLOR_LIGHT_BLUE .. "for general macros." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_RESET .. "(C) " .. COLOR_LIGHT_BLUE .. "for character-specific macros." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - " .. COLOR_RESET .. "(B) " .. COLOR_LIGHT_BLUE .. "for both general and character-specific macros." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- Sets will be ordered alphabetically." .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         return
     elseif helpSection == "options" then
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         print("Macro Sets - Help: Options" .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
-        
+        print(COLOR_SKY_BLUE .. "- Type " .. COLOR_YELLOW .. "/ms options " .. COLOR_SKY_BLUE .. "to toggle the MacroSets configuration window." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- The configuration window allows you to toggle certain settings in MacroSets." .. COLOR_RESET)
+        print(COLOR_LIGHT_BLUE .. "  - Each setting describes the expected functionality based on whether it is checked or not." .. COLOR_RESET)
+        print(COLOR_SKY_BLUE .. "- The configuration window toggles are shared across all characters." .. COLOR_RESET)
         print(COLOR_BLUE .. "==============================" .. COLOR_RESET)
         return
     else

--- a/Main.lua
+++ b/Main.lua
@@ -1,5 +1,4 @@
 --TODO
---remove commands for dynamic icons and bar placement toggles
 --add "undo" command
 -----delate
 -----delate all

--- a/Main.lua
+++ b/Main.lua
@@ -10,7 +10,7 @@ local COLOR_VERMILLION = "|cFFD55E00" -- error message
 local COLOR_GREEN = "|cFF009E73" -- success message
 local COLOR_RESET = "|r" -- reset back to original color
 
--- Testing toggles for debugging --
+-- Testing toggles for debugging
 local test = {
     allFunctions = false,
     toggleDynamicIcons = false,
@@ -54,22 +54,11 @@ local function DeepCopyTable(orig)
     return copy
 end
 
--- Create alphabetized macro set list for easier reference when listed --
+-- Create alphabetized macro set list for easier reference when listed
 local sortedSetNames = {}
 local actionBarSlotLimit = 180
 MacroSetsFunctions = MacroSetsFunctions or {}
 MacroSetsDB = MacroSetsDB or {}
-
-if MacroSetsDB.dynamicIcons == nil then
-    MacroSetsDB.dynamicIcons = false
-end
-if MacroSetsDB.replaceBars == nil then
-    MacroSetsDB.replaceBars = true
-end
-if MacroSetsDB.charSpecific == nil then
-    MacroSetsDB.charSpecific = false
-end
-
 MacroSetsBackup = MacroSetsBackup or {}
 
 function MacroSetsFunctions.ToggleDynamicIcons()
@@ -669,11 +658,10 @@ local function ListMacroSets()
         local setDetails = MacroSetsDB[setName]
         if type(setDetails) == 'table' and setDetails.macros then
             local setType = setDetails.type
-            local COLOR_BOTH_INDICATOR = "|cFFFFFF36(B)|r" -- both macro set type indicator
-            local COLOR_GENERAL_INDICATOR = "|cFF36FF4C(G)|r" -- general macro set type indicator
-            local COLOR_CHARACTER_INDICATOR = "|cFF58E5F5(C)|r" -- character macro set type indicator
+            local COLOR_BOTH_INDICATOR = "|cFFFFFF36(B)|r"
+            local COLOR_GENERAL_INDICATOR = "|cFF36FF4C(G)|r"
+            local COLOR_CHARACTER_INDICATOR = "|cFF58E5F5(C)|r"
             local setTypeIndicator = setType == 'c' and COLOR_CHARACTER_INDICATOR or setType == 'g' and COLOR_GENERAL_INDICATOR or COLOR_BOTH_INDICATOR
-            -- local setTypeIndicator = setType == 'c' and "(C)" or setType == 'g' and "(G)" or "(B)"
             print(COLOR_GREEN .. "- " .. COLOR_RESET .. setTypeIndicator .. setName)
         end
     end

--- a/Options.lua
+++ b/Options.lua
@@ -13,25 +13,25 @@ title:SetText("MacroSets Configuration")
 local dynamicIconsCheckbox = CreateFrame("CheckButton", "DynamicIconsCheckbox", macroSetsOptionsPanel, "InterfaceOptionsCheckButtonTemplate")
 dynamicIconsCheckbox:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -20)
 dynamicIconsCheckbox.text = _G[dynamicIconsCheckbox:GetName() .. "Text"]
-dynamicIconsCheckbox.text:SetText("Show Icons")
-dynamicIconsCheckbox.tooltip = "Toggle showing icons."
+dynamicIconsCheckbox.text:SetFontObject("GameFontNormalLarge")
+dynamicIconsCheckbox.text:SetText("Save initial macro icon")
+dynamicIconsCheckbox.tooltip = "Toggle whether macro icons should default to the question mark dynamic icon or the first icon that is set when saved"
 
 -- Help text for "Show Icons"
-local dynamicIconsHelpText = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+local dynamicIconsHelpText = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
 dynamicIconsHelpText:SetPoint("TOPLEFT", dynamicIconsCheckbox, "BOTTOMLEFT", 0, -5)
-dynamicIconsHelpText:SetText("Icons are currently OFF.")
 
 -- Create checkbox for "Show Bars"
 local replaceBarsCheckbox = CreateFrame("CheckButton", "ReplaceBarsCheckbox", macroSetsOptionsPanel, "InterfaceOptionsCheckButtonTemplate")
 replaceBarsCheckbox:SetPoint("TOPLEFT", dynamicIconsCheckbox, "BOTTOMLEFT", 0, -40)
 replaceBarsCheckbox.text = _G[replaceBarsCheckbox:GetName() .. "Text"]
+replaceBarsCheckbox.text:SetFontObject("GameFontNormalLarge")
 replaceBarsCheckbox.text:SetText("Place loaded macros on action bars")
 replaceBarsCheckbox.tooltip = "Toggle whether macros should be placed on action bars when a macro set is loaded."
 
 -- Help text for "Show Bars"
-local replaceBarsHelpText = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+local replaceBarsHelpText = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
 replaceBarsHelpText:SetPoint("TOPLEFT", replaceBarsCheckbox, "BOTTOMLEFT", 0, -5)
-replaceBarsHelpText:SetText("Macros will not be placed on your action bars when a macro set is loaded.")
 
 -- Function to save the values of the checkboxes
 local function saveSettings()
@@ -40,53 +40,40 @@ local function saveSettings()
     MacroSetsDB.replaceBars = replaceBarsCheckbox:GetChecked()
 end
 
--- Synchronize the checkboxes with MacroSetsDB after saving
-dynamicIconsCheckbox:SetChecked(MacroSetsDB.dynamicIcons)
-replaceBarsCheckbox:SetChecked(MacroSetsDB.replaceBars)
+-- Function to update help text based on current settings
+local function updateHelpText()
+    if MacroSetsDB.dynamicIcons then
+        dynamicIconsHelpText:SetText("All macros are saved with the currently shown icon unless there is a '#i' at the end of the macro name.")
+    else
+        dynamicIconsHelpText:SetText("All macros are saved with the dynamic question mark icon unless there is a '#i' at the end of the macro name.")
+    end
+
+    if MacroSetsDB.replaceBars then
+        replaceBarsHelpText:SetText("Macros will be placed on your action bars when a macro set is loaded.")
+    else
+        replaceBarsHelpText:SetText("Macros will not be placed on your action bars when a macro set is loaded.")
+    end
+end
 
 -- Function to load the values of the checkboxes
 local function loadSettings()
     if not MacroSetsDB then MacroSetsDB = {} end
     dynamicIconsCheckbox:SetChecked(MacroSetsDB.dynamicIcons)
     replaceBarsCheckbox:SetChecked(MacroSetsDB.replaceBars)
-
-    -- Update help text based on the loaded settings
-    if MacroSetsDB.dynamicIcons then
-        dynamicIconsHelpText:SetText("Icons are currently ON.")
-    else
-        dynamicIconsHelpText:SetText("Icons are currently OFF.")
-    end
-
-    if MacroSetsDB.replaceBars then
-        replaceBarsHelpText:SetText("Macros will be placed on your action bars when a macro set is loaded.")
-    else
-        replaceBarsHelpText:SetText("Macros will not be placed on your action bars when a macro set is loaded.")
-    end
-    
+    updateHelpText()
 end
 
 -- Add scripts to handle checkbox toggles
 dynamicIconsCheckbox:SetScript("OnClick", function(self)
     MacroSetsFunctions.ToggleDynamicIcons()
     saveSettings()
-    if MacroSetsDB.dynamicIcons then
-        dynamicIconsHelpText:SetText("Icons are currently ON.")
-    else
-        dynamicIconsHelpText:SetText("Icons are currently OFF.")
-    end
+    updateHelpText()
 end)
 
 replaceBarsCheckbox:SetScript("OnClick", function(self)
-    -- Toggle the internal state
     MacroSetsFunctions.ToggleActionBarPlacements()
     saveSettings()
-    
-    -- Update the help text to match the new state
-    if MacroSetsDB.replaceBars then
-        replaceBarsHelpText:SetText("Macros will be placed on your action bars when a macro set is loaded.")
-    else
-        replaceBarsHelpText:SetText("Macros will not be placed on your action bars when a macro set is loaded.")
-    end
+    updateHelpText()
 end)
 
 -- Register the options panel with the WoW interface
@@ -103,10 +90,7 @@ macroSetsOptionsPanel.default = function()
     replaceBarsCheckbox:SetChecked(true)
     saveSettings()
     loadSettings()
-    
-    -- Update help text based on default values
-    dynamicIconsHelpText:SetText("Icons are currently OFF.")
-    replaceBarsHelpText:SetText("Macros will be placed on your action bars when a macro set is loaded.")
+    updateHelpText()
 end
 
 -- Register the options panel properly with the older, reliable method
@@ -115,18 +99,7 @@ Settings.RegisterAddOnCategory(Settings.RegisterCanvasLayoutCategory(macroSetsOp
 -- Load settings when the addon is loaded
 macroSetsOptionsPanel:SetScript("OnShow", function()
     loadSettings()
-    -- Update help text based on initial load
-    if MacroSetsDB.dynamicIcons then
-        dynamicIconsHelpText:SetText("Icons are currently ON.")
-    else
-        dynamicIconsHelpText:SetText("Icons are currently OFF.")
-    end
-
-    if MacroSetsDB.replaceBars then
-        replaceBarsHelpText:SetText("Macros will be placed on your action bars when a macro set is loaded.")
-    else
-        replaceBarsHelpText:SetText("Macros will not be placed on your action bars when a macro set is loaded.")
-    end
+    updateHelpText()
 end)
 
 -- Event handling to ensure panel is properly registered

--- a/Options.lua
+++ b/Options.lua
@@ -51,7 +51,6 @@ local charSpecificHelpText = CreateHelpText(checkboxesFrame, charSpecificCheckbo
 
 -- Function to initialize settings if they are not already defined
 local function initializeSettings()
-    MacroSetsDB = MacroSetsDB or {}
     if MacroSetsDB.dynamicIcons == nil then
         MacroSetsDB.dynamicIcons = false
     end

--- a/Options.lua
+++ b/Options.lua
@@ -52,9 +52,15 @@ local charSpecificHelpText = CreateHelpText(checkboxesFrame, charSpecificCheckbo
 -- Function to initialize settings if they are not already defined
 local function initializeSettings()
     MacroSetsDB = MacroSetsDB or {}
-    MacroSetsDB.dynamicIcons = MacroSetsDB.dynamicIcons ~= nil and MacroSetsDB.dynamicIcons or false
-    MacroSetsDB.replaceBars = MacroSetsDB.replaceBars ~= nil and MacroSetsDB.replaceBars or true
-    MacroSetsDB.charSpecific = MacroSetsDB.charSpecific ~= nil and MacroSetsDB.charSpecific or false
+    if MacroSetsDB.dynamicIcons == nil then
+        MacroSetsDB.dynamicIcons = false
+    end
+    if MacroSetsDB.replaceBars == nil then
+        MacroSetsDB.replaceBars = true
+    end
+    if MacroSetsDB.charSpecific == nil then
+        MacroSetsDB.charSpecific = false
+    end
 end
 
 -- Function to save the current values of the checkboxes

--- a/Options.lua
+++ b/Options.lua
@@ -1,0 +1,144 @@
+-- Create a configuration frame for the addon
+local macroSetsOptionsPanel = CreateFrame("Frame", "MacroSetsOptionsPanel", UIParent, "BackdropTemplate")
+macroSetsOptionsPanel.name = "MacroSets"
+macroSetsOptionsPanel:SetSize(400, 400)
+macroSetsOptionsPanel:SetPoint("CENTER")
+
+-- Title for the panel
+local title = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge")
+title:SetPoint("TOPLEFT", 16, -16)
+title:SetText("MacroSets Configuration")
+
+-- Create checkbox for "Show Icons"
+local dynamicIconsCheckbox = CreateFrame("CheckButton", "DynamicIconsCheckbox", macroSetsOptionsPanel, "InterfaceOptionsCheckButtonTemplate")
+dynamicIconsCheckbox:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -20)
+dynamicIconsCheckbox.text = _G[dynamicIconsCheckbox:GetName() .. "Text"]
+dynamicIconsCheckbox.text:SetText("Show Icons")
+dynamicIconsCheckbox.tooltip = "Toggle showing icons."
+
+-- Help text for "Show Icons"
+local dynamicIconsHelpText = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+dynamicIconsHelpText:SetPoint("TOPLEFT", dynamicIconsCheckbox, "BOTTOMLEFT", 0, -5)
+dynamicIconsHelpText:SetText("Icons are currently OFF.")
+
+-- Create checkbox for "Show Bars"
+local replaceBarsCheckbox = CreateFrame("CheckButton", "ReplaceBarsCheckbox", macroSetsOptionsPanel, "InterfaceOptionsCheckButtonTemplate")
+replaceBarsCheckbox:SetPoint("TOPLEFT", dynamicIconsCheckbox, "BOTTOMLEFT", 0, -40)
+replaceBarsCheckbox.text = _G[replaceBarsCheckbox:GetName() .. "Text"]
+replaceBarsCheckbox.text:SetText("Place loaded macros on action bars")
+replaceBarsCheckbox.tooltip = "Toggle whether macros should be placed on action bars when a macro set is loaded."
+
+-- Help text for "Show Bars"
+local replaceBarsHelpText = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+replaceBarsHelpText:SetPoint("TOPLEFT", replaceBarsCheckbox, "BOTTOMLEFT", 0, -5)
+replaceBarsHelpText:SetText("Macros will not be placed on your action bars when a macro set is loaded.")
+
+-- Function to save the values of the checkboxes
+local function saveSettings()
+    if not MacroSetsDB then MacroSetsDB = {} end
+    MacroSetsDB.dynamicIcons = dynamicIconsCheckbox:GetChecked()
+    MacroSetsDB.replaceBars = replaceBarsCheckbox:GetChecked()
+end
+
+-- Synchronize the checkboxes with MacroSetsDB after saving
+dynamicIconsCheckbox:SetChecked(MacroSetsDB.dynamicIcons)
+replaceBarsCheckbox:SetChecked(MacroSetsDB.replaceBars)
+
+-- Function to load the values of the checkboxes
+local function loadSettings()
+    if not MacroSetsDB then MacroSetsDB = {} end
+    dynamicIconsCheckbox:SetChecked(MacroSetsDB.dynamicIcons)
+    replaceBarsCheckbox:SetChecked(MacroSetsDB.replaceBars)
+
+    -- Update help text based on the loaded settings
+    if MacroSetsDB.dynamicIcons then
+        dynamicIconsHelpText:SetText("Icons are currently ON.")
+    else
+        dynamicIconsHelpText:SetText("Icons are currently OFF.")
+    end
+
+    if MacroSetsDB.replaceBars then
+        replaceBarsHelpText:SetText("Macros will be placed on your action bars when a macro set is loaded.")
+    else
+        replaceBarsHelpText:SetText("Macros will not be placed on your action bars when a macro set is loaded.")
+    end
+    
+end
+
+-- Add scripts to handle checkbox toggles
+dynamicIconsCheckbox:SetScript("OnClick", function(self)
+    MacroSetsFunctions.ToggleDynamicIcons()
+    saveSettings()
+    if MacroSetsDB.dynamicIcons then
+        dynamicIconsHelpText:SetText("Icons are currently ON.")
+    else
+        dynamicIconsHelpText:SetText("Icons are currently OFF.")
+    end
+end)
+
+replaceBarsCheckbox:SetScript("OnClick", function(self)
+    -- Toggle the internal state
+    MacroSetsFunctions.ToggleActionBarPlacements()
+    saveSettings()
+    
+    -- Update the help text to match the new state
+    if MacroSetsDB.replaceBars then
+        replaceBarsHelpText:SetText("Macros will be placed on your action bars when a macro set is loaded.")
+    else
+        replaceBarsHelpText:SetText("Macros will not be placed on your action bars when a macro set is loaded.")
+    end
+end)
+
+-- Register the options panel with the WoW interface
+macroSetsOptionsPanel.okay = function()
+    saveSettings()
+end
+
+macroSetsOptionsPanel.cancel = function()
+    loadSettings()
+end
+
+macroSetsOptionsPanel.default = function()
+    dynamicIconsCheckbox:SetChecked(false)
+    replaceBarsCheckbox:SetChecked(true)
+    saveSettings()
+    loadSettings()
+    
+    -- Update help text based on default values
+    dynamicIconsHelpText:SetText("Icons are currently OFF.")
+    replaceBarsHelpText:SetText("Macros will be placed on your action bars when a macro set is loaded.")
+end
+
+-- Register the options panel properly with the older, reliable method
+Settings.RegisterAddOnCategory(Settings.RegisterCanvasLayoutCategory(macroSetsOptionsPanel, macroSetsOptionsPanel.name))
+
+-- Load settings when the addon is loaded
+macroSetsOptionsPanel:SetScript("OnShow", function()
+    loadSettings()
+    -- Update help text based on initial load
+    if MacroSetsDB.dynamicIcons then
+        dynamicIconsHelpText:SetText("Icons are currently ON.")
+    else
+        dynamicIconsHelpText:SetText("Icons are currently OFF.")
+    end
+
+    if MacroSetsDB.replaceBars then
+        replaceBarsHelpText:SetText("Macros will be placed on your action bars when a macro set is loaded.")
+    else
+        replaceBarsHelpText:SetText("Macros will not be placed on your action bars when a macro set is loaded.")
+    end
+end)
+
+-- Event handling to ensure panel is properly registered
+local function onEvent(self, event, arg1)
+    if event == "ADDON_LOADED" and arg1 == "MacroSets" then
+        loadSettings()
+    end
+end
+
+local eventFrame = CreateFrame("Frame")
+eventFrame:RegisterEvent("ADDON_LOADED")
+eventFrame:SetScript("OnEvent", onEvent)
+
+-- Ensure the frame is added to the Interface AddOns list
+table.insert(UISpecialFrames, macroSetsOptionsPanel:GetName())

--- a/Options.lua
+++ b/Options.lua
@@ -1,64 +1,76 @@
--- Create a configuration frame for the addon
-local macroSetsOptionsPanel = CreateFrame("Frame", "MacroSetsOptionsPanel", UIParent, "BackdropTemplate")
+-- Create a configuration frame for the addon settings UI
+macroSetsOptionsPanel = CreateFrame("Frame", "MacroSetsOptionsPanel", UIParent, "BackdropTemplate")
+
 macroSetsOptionsPanel.name = "MacroSets"
 local screenWidth = GetScreenWidth()
 local screenHeight = GetScreenHeight()
 macroSetsOptionsPanel:SetSize(screenWidth * 0.4, screenHeight * 0.6)
 macroSetsOptionsPanel:SetPoint("CENTER")
 
--- Title for the panel
+-- Title for the options panel
 local title = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge")
 title:SetPoint("TOPLEFT", 16, -16)
 title:SetText("MacroSets Configuration")
 
--- Create a sub-frame for checkboxes with a border
+-- Create a sub-frame for the checkboxes
 local checkboxesFrame = CreateFrame("Frame", "CheckboxesFrame", macroSetsOptionsPanel)
 checkboxesFrame:SetSize(screenWidth * 0.9 * 0.4, screenHeight * 0.7 * 0.6)
 checkboxesFrame:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -20)
 
--- Create checkbox for "Show Icons"
-local dynamicIconsCheckbox = CreateFrame("CheckButton", "DynamicIconsCheckbox", checkboxesFrame, "InterfaceOptionsCheckButtonTemplate")
-dynamicIconsCheckbox:SetPoint("TOPLEFT", checkboxesFrame, "TOPLEFT", 10, -10)
-dynamicIconsCheckbox.text = _G[dynamicIconsCheckbox:GetName() .. "Text"]
-dynamicIconsCheckbox.text:SetFontObject("GameFontNormalLarge")
-dynamicIconsCheckbox.text:SetText("Save initial macro icon")
-dynamicIconsCheckbox.tooltip = "Toggle whether macro icons should default to the question mark dynamic icon or the first icon that is set when saved"
+-- Helper function to create a checkbox with a label and tooltip
+local function CreateCheckbox(parent, name, labelText, tooltipText, offsetX, offsetY)
+    local checkbox = CreateFrame("CheckButton", name, parent, "InterfaceOptionsCheckButtonTemplate")
+    checkbox:SetPoint("TOPLEFT", parent, "TOPLEFT", offsetX, offsetY)
+    checkbox.text = _G[checkbox:GetName() .. "Text"]
+    checkbox.text:SetFontObject("GameFontNormalLarge")
+    checkbox.text:SetText(labelText)
+    checkbox.tooltip = tooltipText
+    return checkbox
+end
 
--- Help text for "Show Icons"
-local dynamicIconsHelpText = checkboxesFrame:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
-dynamicIconsHelpText:SetWidth(screenWidth * 0.35 * 0.9)
-dynamicIconsHelpText:SetWordWrap(true)
-dynamicIconsHelpText:SetJustifyH("LEFT")
-dynamicIconsHelpText:SetPoint("TOPLEFT", dynamicIconsCheckbox, "BOTTOMLEFT", 0, -5)
+-- Helper function to create help text under checkboxes
+local function CreateHelpText(parent, referenceCheckbox, helpText, offsetX, offsetY)
+    local help = parent:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    help:SetWidth(screenWidth * 0.35 * 0.9)
+    help:SetWordWrap(true)
+    help:SetJustifyH("LEFT")
+    help:SetPoint("TOPLEFT", referenceCheckbox, "BOTTOMLEFT", offsetX, offsetY)
+    help:SetText(helpText)
+    return help
+end
 
--- Create checkbox for "Show Bars"
-local replaceBarsCheckbox = CreateFrame("CheckButton", "ReplaceBarsCheckbox", checkboxesFrame, "InterfaceOptionsCheckButtonTemplate")
-replaceBarsCheckbox:SetPoint("TOPLEFT", dynamicIconsCheckbox, "BOTTOMLEFT", 0, -30)
-replaceBarsCheckbox.text = _G[replaceBarsCheckbox:GetName() .. "Text"]
-replaceBarsCheckbox.text:SetFontObject("GameFontNormalLarge")
-replaceBarsCheckbox.text:SetText("Place loaded macros on action bars")
-replaceBarsCheckbox.tooltip = "Toggle whether macros should be placed on action bars when a macro set is loaded."
+-- Create checkboxes for addon settings with accompanying help text
+local dynamicIconsCheckbox = CreateCheckbox(checkboxesFrame, "DynamicIconsCheckbox", "Save initial macro icon", "Toggle whether macro icons should default to the question mark dynamic icon or the first icon that is set when saved", 10, -10)
+local dynamicIconsHelpText = CreateHelpText(checkboxesFrame, dynamicIconsCheckbox, "", 0, -5)
 
--- Help text for "Show Bars"
-local replaceBarsHelpText = checkboxesFrame:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
-replaceBarsHelpText:SetWidth(screenWidth * 0.35 * 0.9)
-replaceBarsHelpText:SetWordWrap(true)
-replaceBarsHelpText:SetJustifyH("LEFT")
-replaceBarsHelpText:SetPoint("TOPLEFT", replaceBarsCheckbox, "BOTTOMLEFT", 0, -5)
+local replaceBarsCheckbox = CreateCheckbox(checkboxesFrame, "ReplaceBarsCheckbox", "Place loaded macros on action bars", "Toggle whether macros should be placed on action bars when a macro set is loaded.", 10, -80)
+local replaceBarsHelpText = CreateHelpText(checkboxesFrame, replaceBarsCheckbox, "", 0, -5)
 
--- Function to save the values of the checkboxes
+local charSpecificCheckbox = CreateCheckbox(checkboxesFrame, "CharSpecificCheckbox", "Save as character-specific macro set by default", "Toggle whether macro sets are saved as character-specific sets when not specified.", 10, -150)
+local charSpecificHelpText = CreateHelpText(checkboxesFrame, charSpecificCheckbox, "", 0, -5)
+
+-- Function to initialize settings if they are not already defined
+local function initializeSettings()
+    MacroSetsDB = MacroSetsDB or {}
+    MacroSetsDB.dynamicIcons = MacroSetsDB.dynamicIcons ~= nil and MacroSetsDB.dynamicIcons or false
+    MacroSetsDB.replaceBars = MacroSetsDB.replaceBars ~= nil and MacroSetsDB.replaceBars or true
+    MacroSetsDB.charSpecific = MacroSetsDB.charSpecific ~= nil and MacroSetsDB.charSpecific or false
+end
+
+-- Function to save the current values of the checkboxes
 local function saveSettings()
     if not MacroSetsDB then MacroSetsDB = {} end
     MacroSetsDB.dynamicIcons = dynamicIconsCheckbox:GetChecked()
     MacroSetsDB.replaceBars = replaceBarsCheckbox:GetChecked()
+    MacroSetsDB.charSpecific = charSpecificCheckbox:GetChecked()
 end
 
--- Function to update help text based on current settings
+-- Function to update help text descriptions based on current checkbox states
 local function updateHelpText()
     if MacroSetsDB.dynamicIcons then
         dynamicIconsHelpText:SetText("All macros are saved with the currently shown icon unless there is a '#i' at the end of the macro name.")
     else
-        dynamicIconsHelpText:SetText("All macros are saved with the dynamic question mark icon unless there is a '#i' at the end of the macro name.")
+        dynamicIconsHelpText:SetText("All macros are saved with the |T134400:0|t icon unless there is a '#i' at the end of the macro name.")
     end
 
     if MacroSetsDB.replaceBars then
@@ -66,17 +78,24 @@ local function updateHelpText()
     else
         replaceBarsHelpText:SetText("Macros will not be placed on your action bars when a macro set is loaded.")
     end
+
+    if MacroSetsDB.charSpecific then
+        charSpecificHelpText:SetText("Macro sets will be saved as character-specific by default when not specified.")
+    else
+        charSpecificHelpText:SetText("Macro sets will be saved as account-wide by default when not specified.")
+    end
 end
 
--- Function to load the values of the checkboxes
+-- Function to load saved settings into the checkboxes
 local function loadSettings()
-    if not MacroSetsDB then MacroSetsDB = {} end
+    initializeSettings()
     dynamicIconsCheckbox:SetChecked(MacroSetsDB.dynamicIcons)
     replaceBarsCheckbox:SetChecked(MacroSetsDB.replaceBars)
+    charSpecificCheckbox:SetChecked(MacroSetsDB.charSpecific)
     updateHelpText()
 end
 
--- Add scripts to handle checkbox toggles
+-- Set scripts for checkbox interactions
 dynamicIconsCheckbox:SetScript("OnClick", function(self)
     MacroSetsFunctions.ToggleDynamicIcons()
     saveSettings()
@@ -89,33 +108,36 @@ replaceBarsCheckbox:SetScript("OnClick", function(self)
     updateHelpText()
 end)
 
--- Register the options panel with the WoW interface
-macroSetsOptionsPanel.okay = function()
+charSpecificCheckbox:SetScript("OnClick", function(self)
+    MacroSetsFunctions.ToggleCharSpecific()
     saveSettings()
-end
+    updateHelpText()
+end)
 
-macroSetsOptionsPanel.cancel = function()
-    loadSettings()
-end
-
+-- Register the options panel with the WoW interface to manage addon settings
+macroSetsOptionsPanel.okay = saveSettings
+macroSetsOptionsPanel.cancel = loadSettings
 macroSetsOptionsPanel.default = function()
     dynamicIconsCheckbox:SetChecked(false)
     replaceBarsCheckbox:SetChecked(true)
+    charSpecificCheckbox:SetChecked(false)
     saveSettings()
     loadSettings()
     updateHelpText()
 end
 
--- Register the options panel properly with the older, reliable method
-Settings.RegisterAddOnCategory(Settings.RegisterCanvasLayoutCategory(macroSetsOptionsPanel, macroSetsOptionsPanel.name))
+-- Properly register the options panel with the WoW Settings API
+macroSetsCategory = Settings.RegisterCanvasLayoutCategory(macroSetsOptionsPanel, macroSetsOptionsPanel.name)
+Settings.RegisterAddOnCategory(macroSetsCategory)
 
--- Load settings when the addon is loaded
+
+-- Load settings when the options panel is shown
 macroSetsOptionsPanel:SetScript("OnShow", function()
     loadSettings()
     updateHelpText()
 end)
 
--- Event handling to ensure panel is properly registered
+-- Event handling to ensure settings are loaded when the addon is initialized
 local function onEvent(self, event, arg1)
     if event == "ADDON_LOADED" and arg1 == "MacroSets" then
         loadSettings()
@@ -126,5 +148,6 @@ local eventFrame = CreateFrame("Frame")
 eventFrame:RegisterEvent("ADDON_LOADED")
 eventFrame:SetScript("OnEvent", onEvent)
 
--- Ensure the frame is added to the Interface AddOns list
+-- Add the options panel to the list of special frames
+-- This ensures the panel can be closed with the Escape key
 table.insert(UISpecialFrames, macroSetsOptionsPanel:GetName())

--- a/Options.lua
+++ b/Options.lua
@@ -1,7 +1,9 @@
 -- Create a configuration frame for the addon
 local macroSetsOptionsPanel = CreateFrame("Frame", "MacroSetsOptionsPanel", UIParent, "BackdropTemplate")
 macroSetsOptionsPanel.name = "MacroSets"
-macroSetsOptionsPanel:SetSize(400, 400)
+local screenWidth = GetScreenWidth()
+local screenHeight = GetScreenHeight()
+macroSetsOptionsPanel:SetSize(screenWidth * 0.4, screenHeight * 0.6)
 macroSetsOptionsPanel:SetPoint("CENTER")
 
 -- Title for the panel
@@ -9,28 +11,39 @@ local title = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontNo
 title:SetPoint("TOPLEFT", 16, -16)
 title:SetText("MacroSets Configuration")
 
+-- Create a sub-frame for checkboxes with a border
+local checkboxesFrame = CreateFrame("Frame", "CheckboxesFrame", macroSetsOptionsPanel)
+checkboxesFrame:SetSize(screenWidth * 0.9 * 0.4, screenHeight * 0.7 * 0.6)
+checkboxesFrame:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -20)
+
 -- Create checkbox for "Show Icons"
-local dynamicIconsCheckbox = CreateFrame("CheckButton", "DynamicIconsCheckbox", macroSetsOptionsPanel, "InterfaceOptionsCheckButtonTemplate")
-dynamicIconsCheckbox:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -20)
+local dynamicIconsCheckbox = CreateFrame("CheckButton", "DynamicIconsCheckbox", checkboxesFrame, "InterfaceOptionsCheckButtonTemplate")
+dynamicIconsCheckbox:SetPoint("TOPLEFT", checkboxesFrame, "TOPLEFT", 10, -10)
 dynamicIconsCheckbox.text = _G[dynamicIconsCheckbox:GetName() .. "Text"]
 dynamicIconsCheckbox.text:SetFontObject("GameFontNormalLarge")
 dynamicIconsCheckbox.text:SetText("Save initial macro icon")
 dynamicIconsCheckbox.tooltip = "Toggle whether macro icons should default to the question mark dynamic icon or the first icon that is set when saved"
 
 -- Help text for "Show Icons"
-local dynamicIconsHelpText = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+local dynamicIconsHelpText = checkboxesFrame:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+dynamicIconsHelpText:SetWidth(screenWidth * 0.35 * 0.9)
+dynamicIconsHelpText:SetWordWrap(true)
+dynamicIconsHelpText:SetJustifyH("LEFT")
 dynamicIconsHelpText:SetPoint("TOPLEFT", dynamicIconsCheckbox, "BOTTOMLEFT", 0, -5)
 
 -- Create checkbox for "Show Bars"
-local replaceBarsCheckbox = CreateFrame("CheckButton", "ReplaceBarsCheckbox", macroSetsOptionsPanel, "InterfaceOptionsCheckButtonTemplate")
-replaceBarsCheckbox:SetPoint("TOPLEFT", dynamicIconsCheckbox, "BOTTOMLEFT", 0, -40)
+local replaceBarsCheckbox = CreateFrame("CheckButton", "ReplaceBarsCheckbox", checkboxesFrame, "InterfaceOptionsCheckButtonTemplate")
+replaceBarsCheckbox:SetPoint("TOPLEFT", dynamicIconsCheckbox, "BOTTOMLEFT", 0, -30)
 replaceBarsCheckbox.text = _G[replaceBarsCheckbox:GetName() .. "Text"]
 replaceBarsCheckbox.text:SetFontObject("GameFontNormalLarge")
 replaceBarsCheckbox.text:SetText("Place loaded macros on action bars")
 replaceBarsCheckbox.tooltip = "Toggle whether macros should be placed on action bars when a macro set is loaded."
 
 -- Help text for "Show Bars"
-local replaceBarsHelpText = macroSetsOptionsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+local replaceBarsHelpText = checkboxesFrame:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+replaceBarsHelpText:SetWidth(screenWidth * 0.35 * 0.9)
+replaceBarsHelpText:SetWordWrap(true)
+replaceBarsHelpText:SetJustifyH("LEFT")
 replaceBarsHelpText:SetPoint("TOPLEFT", replaceBarsCheckbox, "BOTTOMLEFT", 0, -5)
 
 -- Function to save the values of the checkboxes

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Macro Sets is an addon for Retail World of Warcraft that allows players to manag
 - Separate handling for general and character-specific macros.
 - Easy-to-use slash commands for managing macro sets.
 - Control over how macro icons are stored and set.
+- Undo command incase you make a mistake.
 
 ## Installation
 
@@ -23,35 +24,19 @@ Macro Sets is an addon for Retail World of Warcraft that allows players to manag
 
 ## Usage
 
-- `/ms save [name] [type]`: Save the current macro set with the specified name. Example: /ms save mySet g.
-  - `[name]` 50 characters limit. No spaces.
-  - `[type]` Defaults to `"both"` if omitted.
-    - `"g"`: Save general macros as a set.
-    - `"c"`: Save character-specific macros as a set.
+- `/ms save [name] [type]`: Save the current macro set with the specified name. 
 - `/ms load [name]`: Load the macro set with the specified name.
 - `/ms delete [name]`: Delete the macro set with the specified name.
+- `/ms deleteall`: Delete all saved macro sets.
+- `/ms undo`: Undo the last eligible action.
 - `/ms list`: List all saved macro sets.
-  - Sets will note the tab type they encompass.
-  - Sets will be alphabetized.
-- `/ms bars`: Toggles whether you want the macros to return to their action bar positions on load.
-  - Toggled '**ON**':
-    - Macros will return to their saved action bar positions on load.
-  - Toggled '**OFF**':
-    - All macros pertaining to the sets scope will be removed from the action bars on load.
-  - Set to '**ON**' by default.
-- `/ms icons`: Toggles what the `#i` flag does at the end of macro names
-  - Toggled '**ON**':
-    - Macros with names that end with `#i` will be saved with the default/dynamic question mark icon.
-    - All other macros will be saved with the first icon shown when placed on the action bar.
-  - Toggled '**OFF**':
-    - Macros with names that end with `#i` will be saved with the first icon shown when placed on the action bar.
-    - All other macros will be saved with the default/dynamic question mark icon.
-  - Set to '**OFF**' by default.
-- `/ms help`: Display help information for the addon.
+- `/ms options`: Toggle the options screen.
+- `/ms help`: Display this list of available commands.
+- `/ms help [command]`: Display detailed information about a specific command.
 
-## Explanation for `/ms icons`
+## Explanation for dynamic icon toggle setting
 
-In this section I'll provide a visual example of the way the `/ms icons` affects the addon's functionality as well as an explanation for why it had to exist in the first place.
+In this section I'll provide a visual example of the way the the dynamic icon toggle setting affects the addon's functionality as well as an explanation for why it had to exist in the first place.
 
 ### Why it was necessary
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,13 @@ Macro Sets is an addon for Retail World of Warcraft that allows players to manag
 - Separate handling for general and character-specific macros.
 - Easy-to-use slash commands for managing macro sets.
 - Control over how macro icons are stored and set.
-- Filter your macro sets when listing (WIP).
 
 ## Installation
 
 1. Download the addon.
 2. Extract the ZIP file.
 3. Place the `MacroSets` folder into your `World of Warcraft\_retail_\Interface\AddOns` directory.
-4. Restart World of Warcraft or reload your UI.
+4. Reload your UI or restart World of Warcraft
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Macro Sets is an addon for Retail World of Warcraft that allows players to manag
 ## Features
 
 - Save and load macro sets.
-- Automatically place macros in their saved action bar slots when loading a set
+- Ability to have macros automatically placed in their saved action bar slots when loading a set.
 - Separate handling for general and character-specific macros.
 - Easy-to-use slash commands for managing macro sets.
 - Control over how macro icons are stored and set.
@@ -89,10 +89,16 @@ I've implemented a simple testing framework to assist with debugging. It execute
 ```
 local test = {
     allFunctions = false,
+    toggleDynamicIcons = false,
+    toggleActionBarPlacements = false,
+    toggleCharSpecific = false,
+    backupMacroSets = false,
     alphabetizeMacroSets = false,
     saveMacroSet = false,
     loadMacroSet = false,
     deleteMacroSet = false,
+    deleteAllMacroSets = false,
+    undoLastOperation = false,
     listMacroSets = false,
     displayHelp = false,
     displayDefault = false,
@@ -105,9 +111,8 @@ local test = {
     deleteMacrosInRange = false,
     restoreMacroBodies = false,
     duplicateNames = false,
+    optionsScreenToggle = false,
     handleSlashCommands = false,
-    toggleDynamicIcons = false,
-    toggleActionBarPlacements = false,
 }
 ```
 


### PR DESCRIPTION
**Changes**

- options configuration screen
- 3 toggles in the options config screen
- removed 2 commands (`/ms bars` and `/ms icons`)
  - functionalities moved to the options configuration screen
- added 3 commands (`/ms undo`, `/ms deleteall`, and `/ms options`)
  - delete all macro sets with a single command
  - undo a delete, deleteall, save, or undo action
  - open/close the options configuration screen
- tweaked 2 commands (`/ms help` and `/ms list`)
  - help overhaul
  - colorized set type indicators in macro set list
- more tests
- readme, changelog, version, etc... upkeep