### PR TITLE
Codex Test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,20 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Zip Utility
-        run: sudo apt-get install zip
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zip
 
       - name: Determine Tag Name
         id: tag_name
-        run: echo "::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}"
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Create Release Zip File
+        id: create_zip
         run: |
           zip_name="MacroSets-${{ steps.tag_name.outputs.TAG_NAME }}.zip"
-          echo "::set-output name=ZIP_NAME::$zip_name"
+          echo "ZIP_NAME=$zip_name" >> "$GITHUB_OUTPUT"
           zip -r $zip_name . -x '*.git*'


### PR DESCRIPTION
### Motivation
- Ensure the workflow exposes the generated zip filename as a step output so downstream steps can consume `ZIP_NAME`.

### Description
- Add an `id: create_zip` to the zip creation step so the step output is addressable as `steps.create_zip.outputs`.
- Keep the checkout action updated to `actions/checkout@v4` and replace deprecated `::set-output` usage with writes to `GITHUB_OUTPUT` (e.g. `echo "TAG_NAME=..." >> "$GITHUB_OUTPUT"`).
- Make zip installation non-interactive by running `sudo apt-get update` and `sudo apt-get install -y zip` and create the archive with `zip -r ... -x '*.git*'`.

### Testing
- No automated tests were run because this change only modifies a CI workflow file and does not affect runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979205e07e08332b7a822a43261ffe3)